### PR TITLE
Add .deb package generation for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   release:
     types: [released]
   pull_request:
     branches:
-      - main
+      - master
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       APP_NAME: http_trace
     strategy:
+      fail-fast: false
       matrix:
         target:
           # Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,26 +37,31 @@ jobs:
           # Linux
           - { displayName: 32-bit Linux,
               rustTarget: i686-unknown-linux-gnu,
+              debArch: i386,
               testTarget: '',
               runner: 'ubuntu-latest' }
 
           - { displayName: 64-bit Linux,
               rustTarget: x86_64-unknown-linux-gnu,
+              debArch: amd64,
               testTarget: linux-x64,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM32 ARMv6 Linux,
               rustTarget: arm-unknown-linux-gnueabi,
+              debArch: armel,
               testTarget: linux-arm,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM32 ARMv7 Linux,
               rustTarget: armv7-unknown-linux-gnueabihf,
+              debArch: armhf,
               testTarget: linux-arm,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM64 Linux,
               rustTarget: aarch64-unknown-linux-gnu,
+              debArch: arm64,
               testTarget: linux-arm64,
               runner: 'ubuntu-latest' }
 
@@ -141,20 +146,20 @@ jobs:
       - name: Build .deb package
         if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
         run: |
-          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
-          cp ./target/${{ matrix.target.rustTarget }}/release/http_trace dpkg/usr/local/bin/
-          chmod 755 dpkg/usr/local/bin/http_trace
+          mkdir -p dpkg/DEBIAN dpkg/usr/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/${{ env.APP_NAME }} dpkg/usr/bin/
+          chmod 755 dpkg/usr/bin/${{ env.APP_NAME }}
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           cat > dpkg/DEBIAN/control << EOF
-          Package: http_trace
+          Package: ${{ env.APP_NAME }}
           Version: $VERSION
           Architecture: ${{ matrix.target.debArch }}
           Maintainer: richardsondev
           Description: HTTP request tracing tool
           EOF
           sed -i 's/^          //' dpkg/DEBIAN/control
-          dpkg-deb --build dpkg http_trace_${VERSION}_${{ matrix.target.debArch }}.deb
+          dpkg-deb --build dpkg ${{ env.APP_NAME }}_${VERSION}_${{ matrix.target.debArch }}.deb
 
       - name: Upload .deb Release Asset
         if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
@@ -163,4 +168,4 @@ jobs:
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
-          gh release upload ${{ github.event.release.tag_name }} ./http_trace_${VERSION}_${{ matrix.target.debArch }}.deb
+          gh release upload ${{ github.event.release.tag_name }} --clobber ./${{ env.APP_NAME }}_${VERSION}_${{ matrix.target.debArch }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,3 +137,30 @@ jobs:
         with:
           name: http_trace_server-${{ matrix.target.testTarget }}-${{ matrix.target.rustTarget }}
           path: ./publish/${{ matrix.target.testTarget }}
+
+      - name: Build .deb package
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        run: |
+          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/http_trace dpkg/usr/local/bin/
+          chmod 755 dpkg/usr/local/bin/http_trace
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cat > dpkg/DEBIAN/control << EOF
+          Package: http_trace
+          Version: $VERSION
+          Architecture: ${{ matrix.target.debArch }}
+          Maintainer: richardsondev
+          Description: HTTP request tracing tool
+          EOF
+          sed -i 's/^          //' dpkg/DEBIAN/control
+          dpkg-deb --build dpkg http_trace_${VERSION}_${{ matrix.target.debArch }}.deb
+
+      - name: Upload .deb Release Asset
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          gh release upload ${{ github.event.release.tag_name }} ./http_trace_${VERSION}_${{ matrix.target.debArch }}.deb


### PR DESCRIPTION
## Summary

Adds `.deb` package generation to the release workflow for all Linux architectures. Also fixes the CI trigger branch and adds `fail-fast: false`.

## Changes

- Added `debArch` field to each Linux target in the build matrix (`i386`, `amd64`, `armel`, `armhf`, `arm64`)
- Added a `Build .deb package` step that uses `dpkg-deb` to create Debian packages after the binary is compiled
- Added `Upload .deb Release Asset` step with `--clobber` for idempotent re-runs
- Fixed CI trigger branch from `main` to `master` (matching actual default branch)
- Added `fail-fast: false` to strategy so Linux builds complete even if a Windows build fails
- Uses `env.APP_NAME` consistently for binary paths and package naming
- Binary installs to `/usr/bin/http_trace`

## How it works

On a `release` event, each Linux matrix job creates a `.deb` package using `dpkg-deb --build`. The package contains the binary at `/usr/bin/http_trace` and a `DEBIAN/control` file with package name, version (from the release tag), and architecture. The `.deb` is uploaded to the GitHub Release alongside existing raw binaries. The .NET test server build steps are unaffected.

## Architectures

| Debian Arch | Rust Target |
|---|---|
| `amd64` | `x86_64-unknown-linux-gnu` |
| `i386` | `i686-unknown-linux-gnu` |
| `arm64` | `aarch64-unknown-linux-gnu` |
| `armhf` | `armv7-unknown-linux-gnueabihf` |
| `armel` | `arm-unknown-linux-gnueabi` |

## Usage

```bash
sudo dpkg -i http_trace_0.01_amd64.deb
http_trace https://example.com
```
