### PR TITLE
Add nasm for Windows cross-compile builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Add Windows Build Dependencies
         if: ${{ contains(matrix.target.rustTarget, 'pc-windows') }}
-        run: sudo apt install -y gcc-mingw-w64
+        run: sudo apt install -y gcc-mingw-w64 nasm
 
       - name: Add ARM32 Build Dependencies
         if: ${{ contains(matrix.target.rustTarget, 'arm') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,3 +170,4 @@ jobs:
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           gh release upload ${{ github.event.release.tag_name }} --clobber ./${{ env.APP_NAME }}_${VERSION}_${{ matrix.target.debArch }}.deb
+


### PR DESCRIPTION
Fixes the 32-bit Windows cross-compile build failure caused by missing `nasm`.

## Problem

The `aws-lc-sys` crate (pulled in via `openssl` -> `rustls`) requires `nasm` for assembling optimized cryptographic routines on x86 targets. The CI workflow installed `gcc-mingw-w64` for Windows cross-compilation but not `nasm`, causing builds to fail with: `NASM command not found! Build cannot continue.`

## Fix

Add `nasm` to the `apt install` in the Windows build dependencies step.
